### PR TITLE
Add contact form dropdown

### DIFF
--- a/src/components/ContactDropdown.css
+++ b/src/components/ContactDropdown.css
@@ -1,0 +1,282 @@
+.contact-wrapper {
+  position: relative;
+}
+
+.contact-dropdown {
+  position: fixed;
+  width: 300px;
+  background: rgba(24, 76, 83, 0.82);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(242, 140, 30, 0.75);
+  border-radius: 10px 0 10px 10px;
+  padding: 1.25rem;
+  box-shadow: 0 20px 48px -8px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(242, 140, 30, 0.08);
+  animation: dropdown-in 0.2s ease-out forwards;
+  z-index: 200;
+}
+
+@keyframes dropdown-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes shake {
+  0%,  100% { transform: translateX(0); }
+  15%        { transform: translateX(-7px); }
+  30%        { transform: translateX(7px); }
+  45%        { transform: translateX(-5px); }
+  60%        { transform: translateX(5px); }
+  75%        { transform: translateX(-3px); }
+  90%        { transform: translateX(3px); }
+}
+
+.contact-dropdown.shake {
+  animation: shake 0.45s ease;
+}
+
+/* ── Header ─────────────────────────────────────────────── */
+.contact-dropdown-header {
+  position: absolute;
+  top: 0.45rem;
+  right: 0.45rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.contact-dropdown-title {
+  font-family: var(--font-display);
+  font-size: 0.8rem;
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.contact-close-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  color: var(--fg3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: color var(--transition-base), background var(--transition-base);
+}
+
+.contact-close-btn:hover {
+  color: var(--accent);
+}
+
+.contact-close-btn svg {
+  width: 12px;
+  height: 12px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+/* ── Form ───────────────────────────────────────────────── */
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.contact-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.28rem;
+}
+
+.contact-field label {
+  font-size: 0.68rem;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--fg3);
+}
+
+.contact-field input,
+.contact-field textarea {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(102, 200, 227, 0.18);
+  border-radius: 6px;
+  padding: 0.48rem 0.72rem;
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  color: var(--fg1);
+  outline: none;
+  resize: none;
+  transition: border-color var(--transition-base), background var(--transition-base);
+}
+
+.contact-field input::placeholder,
+.contact-field textarea::placeholder {
+  color: var(--fg3);
+}
+
+.contact-field input:focus,
+.contact-field textarea:focus {
+  border-color: rgba(242, 140, 30, 0.5);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+/* ── Submit ─────────────────────────────────────────────── */
+.contact-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0.52rem 1rem;
+  margin-top: 0.2rem;
+  border-radius: 6px;
+  border: 1px solid rgba(242, 140, 30, 0.5);
+  background: rgba(242, 140, 30, 0.12);
+  color: var(--accent);
+  font-family: var(--font-body);
+  font-size: 0.76rem;
+  font-weight: var(--weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  width: 100%;
+  transition: all var(--transition-base);
+}
+
+.contact-submit:hover {
+  background: rgba(242, 140, 30, 0.22);
+  border-color: rgba(242, 140, 30, 0.75);
+  color: var(--accent-hover);
+}
+
+.contact-submit svg {
+  width: 10px;
+  height: 10px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+/* ── Success overlay ────────────────────────────────────── */
+.contact-success-overlay {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: rgba(18, 56, 62, 0.50);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: overlay-in 0.3s ease forwards;
+}
+
+@keyframes overlay-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.contact-success-icon {
+  width: 72px;
+  height: 72px;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.contact-success-icon circle {
+  stroke: rgba(242, 140, 30, 0.6);
+  stroke-width: 2;
+  stroke-dasharray: 152;
+  stroke-dashoffset: 152;
+  animation: circle-draw 0.5s ease 0.1s forwards;
+}
+
+.contact-success-icon path {
+  stroke: var(--accent-hover);
+  stroke-width: 3.5;
+  stroke-dasharray: 30;
+  stroke-dashoffset: 30;
+  filter: drop-shadow(0 0 6px rgba(242, 140, 30, 0.8));
+  animation: check-draw 0.4s ease 0.45s forwards;
+}
+
+@keyframes circle-draw {
+  to { stroke-dashoffset: 0; }
+}
+
+@keyframes check-draw {
+  to { stroke-dashoffset: 0; }
+}
+
+/* ── Error ──────────────────────────────────────────────── */
+.contact-field input.input-error,
+.contact-field textarea.input-error {
+  border-color: rgba(220, 80, 80, 0.6);
+}
+
+.field-error {
+  font-size: 0.65rem;
+  color: #e07070;
+  letter-spacing: 0.02em;
+}
+
+.contact-error {
+  font-size: 0.72rem;
+  color: #e07070;
+  margin: 0;
+  text-align: center;
+}
+
+.contact-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ── Toast ──────────────────────────────────────────────── */
+.contact-toast {
+  font-size: 0.67rem;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.04em;
+  color: #e07070;
+  white-space: nowrap;
+  pointer-events: none;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  padding: 0.18rem 0.5rem;
+  animation: toast-in 0.18s ease-out forwards;
+}
+
+.contact-toast span {
+  font-weight: var(--weight-bold);
+}
+
+@keyframes toast-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.contact-toast.fading {
+  animation: toast-out 0.5s ease forwards;
+}
+
+@keyframes toast-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+/* ── Close button highlight ─────────────────────────────── */
+.contact-close-btn.highlight {
+  color: var(--accent);
+}

--- a/src/components/ContactDropdown.tsx
+++ b/src/components/ContactDropdown.tsx
@@ -1,0 +1,184 @@
+import { useState, useEffect, useRef, forwardRef } from "react";
+import "./ContactDropdown.css";
+
+interface Props {
+  onClose: () => void;
+  shakeSignal: number;
+  top: number;
+  right: number;
+}
+
+const ContactDropdown = forwardRef<HTMLDivElement, Props>(function ContactDropdown(
+  { onClose, shakeSignal, top, right }, ref
+) {
+  const [showToast, setShowToast] = useState(false);
+  const [toastFading, setToastFading] = useState(false);
+  const [form, setForm] = useState({ name: "", email: "", phone: "", message: "" });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+  const [status, setStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const toastFadeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (status !== "sent") return;
+    const t = setTimeout(() => onClose(), 2800);
+    return () => clearTimeout(t);
+  }, [status, onClose]);
+
+  useEffect(() => {
+    if (shakeSignal === 0) return;
+    const el = dropdownRef.current;
+    if (!el) return;
+
+    el.classList.remove("shake");
+    void el.offsetWidth;
+    el.classList.add("shake");
+
+    setShowToast(true);
+    setToastFading(false);
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    if (toastFadeRef.current) clearTimeout(toastFadeRef.current);
+    toastTimerRef.current = setTimeout(() => {
+      setToastFading(true);
+      toastFadeRef.current = setTimeout(() => {
+        setShowToast(false);
+        setToastFading(false);
+      }, 500);
+    }, 2000);
+  }, [shakeSignal]);
+
+  const validate = (fields: typeof form) => {
+    const e: Record<string, string> = {};
+    if (!fields.name.trim()) e.name = "Name is required.";
+    else if (fields.name.length > 60) e.name = "Max 60 characters.";
+
+    if (!fields.email.trim()) e.email = "Email is required.";
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(fields.email)) e.email = "Invalid email address.";
+    else if (fields.email.length > 100) e.email = "Max 100 characters.";
+
+    if (fields.phone && !/^[+\d\s\-()]{0,20}$/.test(fields.phone)) e.phone = "Invalid phone number.";
+
+    if (!fields.message.trim()) e.message = "Message is required.";
+    else if (fields.message.length > 500) e.message = "Max 500 characters.";
+
+    return e;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const updated = { ...form, [e.target.name]: e.target.value };
+    setForm(updated);
+    if (errors[e.target.name]) {
+      setErrors(prev => ({ ...prev, [e.target.name]: "" }));
+    }
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setTouched(t => ({ ...t, [e.target.name]: true }));
+    setErrors(validate({ ...form, [e.target.name]: e.target.value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const allTouched = { name: true, email: true, phone: true, message: true };
+    setTouched(allTouched);
+    const errs = validate(form);
+    if (Object.keys(errs).length > 0) { setErrors(errs); return; }
+    setStatus("sending");
+    try {
+      const res = await fetch("https://formspree.io/f/maqvarow", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Accept": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        setStatus("sent");
+        setForm({ name: "", email: "", phone: "", message: "" });
+      } else {
+        setStatus("error");
+      }
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  return (
+    <div className="contact-dropdown" ref={(el) => { dropdownRef.current = el; if (typeof ref === 'function') ref(el); else if (ref) ref.current = el; }} style={{ top, right }}>
+      {(showToast) && (
+        <div className="contact-dropdown-header">
+          <div className={`contact-toast${toastFading ? " fading" : ""}`}>
+            Use <span>Close</span> to exit
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="contact-form">
+          <div className="contact-field">
+            <label htmlFor="cf-name">Name</label>
+            <input
+              id="cf-name" name="name" type="text"
+              value={form.name} onChange={handleChange} onBlur={handleBlur}
+              placeholder="Your name" maxLength={60}
+              className={errors.name && touched.name ? "input-error" : ""}
+            />
+            {errors.name && touched.name && <span className="field-error">{errors.name}</span>}
+          </div>
+          <div className="contact-field">
+            <label htmlFor="cf-email">Email</label>
+            <input
+              id="cf-email" name="email" type="email"
+              value={form.email} onChange={handleChange} onBlur={handleBlur}
+              placeholder="you@example.com" maxLength={100}
+              className={errors.email && touched.email ? "input-error" : ""}
+            />
+            {errors.email && touched.email && <span className="field-error">{errors.email}</span>}
+          </div>
+          <div className="contact-field">
+            <label htmlFor="cf-phone">Phone</label>
+            <input
+              id="cf-phone" name="phone" type="tel"
+              value={form.phone} onChange={handleChange} onBlur={handleBlur}
+              placeholder="(+358) 50 000 0000" maxLength={20}
+              className={errors.phone && touched.phone ? "input-error" : ""}
+            />
+            {errors.phone && touched.phone && <span className="field-error">{errors.phone}</span>}
+          </div>
+          <div className="contact-field">
+            <label htmlFor="cf-message">Message</label>
+            <textarea
+              id="cf-message" name="message"
+              value={form.message} onChange={handleChange} onBlur={handleBlur}
+              placeholder="What's on your mind?" maxLength={500} rows={4}
+              className={errors.message && touched.message ? "input-error" : ""}
+            />
+            {errors.message && touched.message && <span className="field-error">{errors.message}</span>}
+          </div>
+          <button type="submit" className="contact-submit" disabled={status === "sending"}>
+            {status === "sending" ? "Sending…" : status === "error" ? "Try again" : "Send message"}
+            {status !== "sending" && (
+              <svg viewBox="0 0 12 12" aria-hidden="true">
+                <polyline points="9,3 9,7 2,7" />
+                <polyline points="4,5 2,7 4,9" />
+              </svg>
+            )}
+          </button>
+          {status === "error" && (
+            <p className="contact-error">Something went wrong. Please try again.</p>
+          )}
+        </form>
+
+      {status === "sent" && (
+        <div className="contact-success-overlay">
+          <svg className="contact-success-icon" viewBox="0 0 52 52" aria-hidden="true">
+            <circle cx="26" cy="26" r="24" />
+            <path d="M14 27l8 8 16-16" />
+          </svg>
+        </div>
+      )}
+
+    </div>
+  );
+});
+
+export default ContactDropdown;

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -189,6 +189,8 @@
   gap: 6px;
   padding: 0.42rem 1rem;
   border-radius: 6px;
+  white-space: nowrap;
+  overflow: hidden;
   border: 1px solid rgba(242, 140, 30, 0.50);
   background: rgba(242, 140, 30, 0.10);
   color: var(--accent);
@@ -210,6 +212,15 @@
   box-shadow: 0 6px 18px -8px rgba(242, 140, 30, 0.4);
 }
 
+.btn-cta .btn-label {
+  animation: label-in 0.18s ease;
+}
+
+@keyframes label-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
 .btn-cta svg {
   width: 10px;
   height: 10px;
@@ -217,11 +228,68 @@
   fill: none;
   stroke-width: 2;
   stroke-linecap: round;
-  transition: transform var(--transition-base);
 }
 
 .btn-cta:hover svg {
-  transform: translateX(2px);
+  opacity: 1;
+}
+
+@keyframes btn-shake {
+  0%,  100% { transform: translateX(0); }
+  15%        { transform: translateX(-7px); }
+  30%        { transform: translateX(7px); }
+  45%        { transform: translateX(-5px); }
+  60%        { transform: translateX(5px); }
+  75%        { transform: translateX(-3px); }
+  90%        { transform: translateX(3px); }
+}
+
+.btn-cta.shake {
+  animation: btn-shake 0.45s ease;
+}
+
+.contact-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99;
+  cursor: default;
+}
+
+.header.contact-open {
+  z-index: 200;
+}
+
+.btn-cta.highlighted {
+  background: rgba(242, 140, 30, 0.28);
+  border-color: var(--accent);
+  color: var(--accent-hover);
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.btn-cta.active.highlighted {
+  background: rgba(242, 140, 30, 0.75);
+  border-color: rgba(242, 140, 30, 1);
+  color: #fff;
+  border-bottom-color: transparent;
+  transition: background 0.5s ease, border-color 0.5s ease, color 0.5s ease;
+}
+
+.btn-cta.active {
+  background: rgba(242, 140, 30, 0.55);
+  border-color: rgba(242, 140, 30, 0.90);
+  color: #fff;
+  border-bottom-color: transparent;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.btn-cta.active:hover {
+  background: rgba(242, 140, 30, 0.75);
+  border-color: rgba(242, 140, 30, 1);
+  color: #fff;
+  transform: none;
+  box-shadow: 0 4px 14px -4px rgba(242, 140, 30, 0.5);
+  border-bottom-color: transparent;
 }
 
 @media (max-width: 768px) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,21 @@
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Link, NavLink } from "react-router-dom";
+import ContactDropdown from "./ContactDropdown";
 import "./Header.css";
 
 export default function Header() {
   const [scrolled, setScrolled] = useState(false);
+  const [contactOpen, setContactOpen] = useState(false);
+  const [shakeCount, setShakeCount] = useState(0);
+  const [btnHighlighted, setBtnHighlighted] = useState(false);
+  const [dropdownPos, setDropdownPos] = useState({ top: 0, right: 0 });
+  const contactBtnRef = useRef<HTMLButtonElement>(null);
+  const contactWrapperRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const prevBtnWidthRef = useRef<number | null>(null);
+  const btnHighlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const btnHighlightFadeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const onScroll = () => {
@@ -15,64 +27,124 @@ export default function Header() {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
+  useEffect(() => {
+    if (shakeCount === 0) return;
+    const btn = contactBtnRef.current;
+    if (!btn) return;
+    btn.classList.remove("shake");
+    void btn.offsetWidth;
+    btn.classList.add("shake");
+
+    setBtnHighlighted(true);
+    if (btnHighlightTimerRef.current) clearTimeout(btnHighlightTimerRef.current);
+    if (btnHighlightFadeRef.current) clearTimeout(btnHighlightFadeRef.current);
+    btnHighlightTimerRef.current = setTimeout(() => {
+      setBtnHighlighted(false);
+    }, 2000);
+  }, [shakeCount]);
+
+  useEffect(() => {
+    if (!contactOpen) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      const insideWrapper = contactWrapperRef.current?.contains(target);
+      const insideDropdown = dropdownRef.current?.contains(target);
+      if (!insideWrapper && !insideDropdown) {
+        e.preventDefault();
+        setShakeCount(c => c + 1);
+      }
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [contactOpen]);
+
+  useLayoutEffect(() => {
+    const btn = contactBtnRef.current;
+    if (!btn) return;
+    if (prevBtnWidthRef.current === null) {
+      prevBtnWidthRef.current = btn.offsetWidth;
+      return;
+    }
+    const oldWidth = prevBtnWidthRef.current;
+    btn.style.width = "";
+    const newWidth = btn.offsetWidth;
+    prevBtnWidthRef.current = newWidth;
+    btn.style.transition = "none";
+    btn.style.width = oldWidth + "px";
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      btn.style.transition = "width 0.22s ease";
+      btn.style.width = newWidth + "px";
+    }));
+    const t = setTimeout(() => { btn.style.width = ""; btn.style.transition = ""; }, 240);
+    return () => clearTimeout(t);
+  }, [contactOpen]);
+
+  const openContact = () => {
+    if (contactOpen) {
+      setShakeCount(0);
+      setBtnHighlighted(false);
+      if (btnHighlightTimerRef.current) clearTimeout(btnHighlightTimerRef.current);
+      contactBtnRef.current?.classList.remove("shake");
+    } else if (contactBtnRef.current) {
+      const rect = contactBtnRef.current.getBoundingClientRect();
+      setDropdownPos({ top: rect.bottom, right: window.innerWidth - rect.right });
+    }
+    setContactOpen(o => !o);
+  };
+
   return (
     <header className={`header${scrolled ? " scrolled" : ""}`}>
       <div className="header-inner">
         <Link to="/" className="wordmark">Daniel Virtanen</Link>
         <span className="header-tagline">Designer. Developer.</span>
         <nav className="nav">
-          <NavLink
-            to="/"
-            end
-            className={({ isActive }) => `nav-link${isActive ? " active" : ""}`}
-          >
+          <NavLink to="/" end className={({ isActive }) => `nav-link${isActive ? " active" : ""}`}>
             Home
           </NavLink>
-          <NavLink
-            to="/work"
-            className={({ isActive }) => `nav-link${isActive ? " active" : ""}`}
-          >
+          <NavLink to="/work" className={({ isActive }) => `nav-link${isActive ? " active" : ""}`}>
             Work
           </NavLink>
-          <NavLink
-            to="/about"
-            className={({ isActive }) => `nav-link${isActive ? " active" : ""}`}
-          >
+          <NavLink to="/about" className={({ isActive }) => `nav-link${isActive ? " active" : ""}`}>
             About
           </NavLink>
         </nav>
         <div className="header-actions">
-          <a
-            className="btn-text"
-            href="https://github.com/Dan5ku"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a className="btn-text" href="https://github.com/Dan5ku" target="_blank" rel="noopener noreferrer">
             GitHub
-            <svg viewBox="0 0 12 12" aria-hidden="true">
-              <path d="M2 10L10 2M5 2h5v5" />
-            </svg>
+            <svg viewBox="0 0 12 12" aria-hidden="true"><path d="M2 10L10 2M5 2h5v5" /></svg>
           </a>
-          <a
-            className="btn-text"
-            href="https://linkedin.com"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a className="btn-text" href="https://linkedin.com" target="_blank" rel="noopener noreferrer">
             LinkedIn
-            <svg viewBox="0 0 12 12" aria-hidden="true">
-              <path d="M2 10L10 2M5 2h5v5" />
-            </svg>
+            <svg viewBox="0 0 12 12" aria-hidden="true"><path d="M2 10L10 2M5 2h5v5" /></svg>
           </a>
-          <Link to="/contact" className="btn-cta">
-            Contact
-            <svg viewBox="0 0 12 12" aria-hidden="true">
-              <polyline points="2,6 10,6 7,3" />
-              <polyline points="7,9 10,6" />
-            </svg>
-          </Link>
+          <div className="contact-wrapper" ref={contactWrapperRef}>
+            <button
+              ref={contactBtnRef}
+              className={`btn-cta${contactOpen ? " active" : ""}${btnHighlighted ? " highlighted" : ""}`}
+              onClick={openContact}
+            >
+              <span key={contactOpen ? "close" : "open"} className="btn-label">
+                {contactOpen ? "Close" : "Get in touch"}
+              </span>
+              {contactOpen
+                ? <svg viewBox="0 0 12 12" aria-hidden="true"><path d="M1 1l10 10M11 1L1 11" /></svg>
+                : <svg viewBox="0 0 12 12" aria-hidden="true"><polyline points="2,4 6,8 10,4" /></svg>
+              }
+            </button>
+          </div>
         </div>
       </div>
+
+      {contactOpen && createPortal(
+        <ContactDropdown
+          onClose={() => { setContactOpen(false); setShakeCount(0); }}
+          shakeSignal={shakeCount}
+          top={dropdownPos.top}
+          right={dropdownPos.right}
+          ref={dropdownRef}
+        />,
+        document.body
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- Header button opens a dropdown contact form (name, email, phone, message)
- Sends via Formspree; animated checkmark overlay on success, auto-closes after 2.8s
- Click outside shakes the form and button, shows a timed toast pointing to Close
- Full field validation (required, format, max length) with inline error messages

## Test plan
- [ ] Open dropdown via "Get in touch" button
- [ ] Submit empty form — all required errors appear
- [ ] Fill fields, blur with invalid email — error shows, clears on next keystroke
- [ ] Click outside — form and button shake, toast appears and fades in sync
- [ ] Submit valid form — checkmark overlay animates, dropdown closes automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)